### PR TITLE
Handle null WebDriver shutdown

### DIFF
--- a/src/main/java/vznd/selenium/HTMLPath.java
+++ b/src/main/java/vznd/selenium/HTMLPath.java
@@ -10,7 +10,7 @@ public class HTMLPath {
     public static final String CLICK_AND_HOLD = "https://vznd.github.io/selenium-app/pages/click-and-hold.html";
     public static final String CONTEXT_CLICK = "https://vznd.github.io/selenium-app/pages/context-click.html";
     public static final String DOUBLE_CLICK = "https://vznd.github.io/selenium-app/pages/double-click.html";
-    public static final String MOVE_TO_ELEMENT = "https://vznd.github.io/selenium-app/pages/move-to-element.html";;
+    public static final String MOVE_TO_ELEMENT = "https://vznd.github.io/selenium-app/pages/move-to-element.html";
     public static final String KEYBOARD = "https://vznd.github.io/selenium-app/pages/keyboard.html";
     public static final String WINDOWS = "https://vznd.github.io/selenium-app/pages/windows.html";
     public static final String COOKIES = "https://vznd.github.io/selenium-app/pages/cookies.html";

--- a/src/test/java/vznd/selenium/BaseTest.java
+++ b/src/test/java/vznd/selenium/BaseTest.java
@@ -17,7 +17,9 @@ public class BaseTest {
 
     @AfterMethod
     public void tearDown() {
-        driver.quit();
+        if (driver != null) {
+            driver.quit();
+        }
     }
 
     private ChromeOptions getChromeOptions() {


### PR DESCRIPTION
## Summary
- avoid NullPointerException when WebDriver fails to initialize
- remove stray semicolon from MOVE_TO_ELEMENT URL constant

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.0 could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f54bbaf188329934a876ad31fd3d8